### PR TITLE
Fix firefox copypasting

### DIFF
--- a/packages/smooth-code/src/code-spring.tsx
+++ b/packages/smooth-code/src/code-spring.tsx
@@ -10,8 +10,8 @@ import {
 type SpringConfig = Parameters<typeof useSpring>[1]
 
 type HTMLProps = React.DetailedHTMLProps<
-  React.HTMLAttributes<HTMLPreElement>,
-  HTMLPreElement
+  React.HTMLAttributes<HTMLDivElement>,
+  HTMLDivElement
 >
 
 const defaultSpring = {

--- a/packages/smooth-code/src/code-tween.tsx
+++ b/packages/smooth-code/src/code-tween.tsx
@@ -16,8 +16,8 @@ import {
 import { SmoothLines } from "./smooth-lines"
 
 type HTMLProps = React.DetailedHTMLProps<
-  React.HTMLAttributes<HTMLPreElement>,
-  HTMLPreElement
+  React.HTMLAttributes<HTMLDivElement>,
+  HTMLDivElement
 >
 
 export type CodeTweenProps = {
@@ -166,11 +166,13 @@ function Wrapper({
   children: React.ReactNode
 }) {
   return (
-    <pre
+    <div
       {...htmlProps}
       style={{
         margin: 0,
         padding: 0,
+        // using this instead of <pre> because https://github.com/code-hike/codehike/issues/120
+        whiteSpace: "pre",
         ...style,
         ...htmlProps?.style,
       }}


### PR DESCRIPTION
Fix #120 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.0--canary.124.5b2426a.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @code-hike/classer@0.3.0--canary.124.5b2426a.0
  npm install @code-hike/highlighter@0.3.0--canary.124.5b2426a.0
  npm install @code-hike/mdx@0.3.0--canary.124.5b2426a.0
  npm install @code-hike/mini-browser@0.3.0--canary.124.5b2426a.0
  npm install @code-hike/mini-editor@0.3.0--canary.124.5b2426a.0
  npm install @code-hike/mini-frame@0.3.0--canary.124.5b2426a.0
  npm install @code-hike/mini-terminal@0.3.0--canary.124.5b2426a.0
  npm install @code-hike/player@0.3.0--canary.124.5b2426a.0
  npm install @code-hike/playground@0.3.0--canary.124.5b2426a.0
  npm install @code-hike/script@0.3.0--canary.124.5b2426a.0
  npm install @code-hike/scroller@0.3.0--canary.124.5b2426a.0
  npm install @code-hike/scrollycoding@0.3.0--canary.124.5b2426a.0
  npm install @code-hike/sim-user@0.3.0--canary.124.5b2426a.0
  npm install @code-hike/smooth-code@0.3.0--canary.124.5b2426a.0
  npm install @code-hike/smooth-column@0.3.0--canary.124.5b2426a.0
  npm install storybook@0.3.0--canary.124.5b2426a.0
  npm install @code-hike/utils@0.3.0--canary.124.5b2426a.0
  # or 
  yarn add @code-hike/classer@0.3.0--canary.124.5b2426a.0
  yarn add @code-hike/highlighter@0.3.0--canary.124.5b2426a.0
  yarn add @code-hike/mdx@0.3.0--canary.124.5b2426a.0
  yarn add @code-hike/mini-browser@0.3.0--canary.124.5b2426a.0
  yarn add @code-hike/mini-editor@0.3.0--canary.124.5b2426a.0
  yarn add @code-hike/mini-frame@0.3.0--canary.124.5b2426a.0
  yarn add @code-hike/mini-terminal@0.3.0--canary.124.5b2426a.0
  yarn add @code-hike/player@0.3.0--canary.124.5b2426a.0
  yarn add @code-hike/playground@0.3.0--canary.124.5b2426a.0
  yarn add @code-hike/script@0.3.0--canary.124.5b2426a.0
  yarn add @code-hike/scroller@0.3.0--canary.124.5b2426a.0
  yarn add @code-hike/scrollycoding@0.3.0--canary.124.5b2426a.0
  yarn add @code-hike/sim-user@0.3.0--canary.124.5b2426a.0
  yarn add @code-hike/smooth-code@0.3.0--canary.124.5b2426a.0
  yarn add @code-hike/smooth-column@0.3.0--canary.124.5b2426a.0
  yarn add storybook@0.3.0--canary.124.5b2426a.0
  yarn add @code-hike/utils@0.3.0--canary.124.5b2426a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
