### PR TITLE
Rename esm to .mjs

### DIFF
--- a/examples/nextjs/pages/my.md
+++ b/examples/nextjs/pages/my.md
@@ -2,7 +2,7 @@
 
 Lorem ipsum dolor sit amet.
 
-```python hello.py
+```python hello.py mark=1[22:30]
 print("Rendered with Code Hike")
 ```
 

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -5,16 +5,16 @@
     "dist"
   ],
   "main": "./dist/index.cjs.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.esm.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.esm.mjs",
       "require": "./dist/index.cjs.js",
       "style": "./dist/index.css"
     },
     "./components": {
-      "import": "./dist/components.esm.js",
+      "import": "./dist/components.esm.mjs",
       "require": "./dist/components.cjs.js",
       "default": "./dist/components.cjs.js"
     },
@@ -23,13 +23,13 @@
     "./styles.css": "./dist/index.css",
     "./dist/index.css": "./dist/index.css",
     "./dist/components.cjs.js": {
-      "import": "./dist/components.esm.js",
+      "import": "./dist/components.esm.mjs",
       "require": "./dist/components.cjs.js",
       "default": "./dist/components.cjs.js"
     }
   },
   "browser": {
-    "./dist/index.esm.js": "./dist/index.browser.mjs"
+    "./dist/index.esm.mjs": "./dist/index.browser.mjs"
   },
   "scripts": {
     "dev": "next",

--- a/packages/mdx/rollup.config.js
+++ b/packages/mdx/rollup.config.js
@@ -34,7 +34,7 @@ export default function makeConfig(commandOptions) {
           format: "cjs",
         },
         {
-          file: `./dist/index.esm.js`,
+          file: `./dist/index.esm.mjs`,
           format: "es",
         },
       ],
@@ -84,7 +84,7 @@ export default function makeConfig(commandOptions) {
           format: "cjs",
         },
         {
-          file: `./dist/components.esm.js`,
+          file: `./dist/components.esm.mjs`,
           format: "es",
         },
       ],


### PR DESCRIPTION
Fix #156
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.4.0--canary.157.99e69b4.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @code-hike/mdx@0.4.0--canary.157.99e69b4.0
  # or 
  yarn add @code-hike/mdx@0.4.0--canary.157.99e69b4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
