### PR TITLE
Remove target from code links

### DIFF
--- a/packages/mdx/dev/content/comment-annotations.mdx
+++ b/packages/mdx/dev/content/comment-annotations.mdx
@@ -56,6 +56,7 @@ And now we introduce two more annotations: `link` and `label`
 
 ```js focus=4,8
 function lorem(ipsum, dolor = 1) {
+  // link[15:19] #bash-like-comments
   const sit = ipsum == null && 0
   dolor = sit - amet(dolor)
   // link[16:26] https://github.com/code-hike/codehike
@@ -69,7 +70,7 @@ function adipiscing(...elit) {
 }
 ```
 
-Bash like comments
+<h3 id="bash-like-comments">Bash like comments</h3>
 
 ```python
 def lorem(ipsum, dolor = 1):

--- a/packages/mdx/src/mdx-client/annotations.tsx
+++ b/packages/mdx/src/mdx-client/annotations.tsx
@@ -201,8 +201,6 @@ function CodeLink({
   return (
     <a
       href={url}
-      target="_blank"
-      rel="noopener noreferrer"
       title={title}
       style={{
         textDecoration: "underline",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.5.0--canary.169.a3b677d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @code-hike/mdx@0.5.0--canary.169.a3b677d.0
  # or 
  yarn add @code-hike/mdx@0.5.0--canary.169.a3b677d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
