### PR TITLE
Fix react 18 strict mode

### DIFF
--- a/packages/mdx/next.config.js
+++ b/packages/mdx/next.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  reactStrictMode: true,
   redirects() {
     return [
       {

--- a/packages/mdx/src/mini-editor/editor-shift.tsx
+++ b/packages/mdx/src/mini-editor/editor-shift.tsx
@@ -793,21 +793,21 @@ function useSnapshots(
 
   useLayoutEffect(() => {
     if (!prevSnapshot) {
-      // debugger
+      const parent = ref.current!
       setState(s => ({
         ...s,
         prevSnapshot: {
-          ...getPanelSnapshot(ref.current!, prev),
-          ...getTabsSnapshot(ref.current!, prev),
+          ...getPanelSnapshot(parent, prev),
+          ...getTabsSnapshot(parent, prev),
         },
       }))
     } else if (!nextSnapshot) {
-      // debugger
+      const parent = ref.current!
       setState(s => ({
         ...s,
         nextSnapshot: {
-          ...getPanelSnapshot(ref.current!, next),
-          ...getTabsSnapshot(ref.current!, next),
+          ...getPanelSnapshot(parent, next),
+          ...getTabsSnapshot(parent, next),
         },
       }))
     }

--- a/packages/mdx/src/smooth-code/copy-button.tsx
+++ b/packages/mdx/src/smooth-code/copy-button.tsx
@@ -43,7 +43,7 @@ export function CopyButton({
         <path
           strokeLinecap="round"
           strokeLinejoin="round"
-          strokeWidth="2"
+          strokeWidth="1.6px"
           d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
         />
       )}


### PR DESCRIPTION
Fix #161 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.5.0--canary.173.8c6fd0a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @code-hike/mdx@0.5.0--canary.173.8c6fd0a.0
  # or 
  yarn add @code-hike/mdx@0.5.0--canary.173.8c6fd0a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.5.0-next.2`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@code-hike/mdx`
    - Copy button component [#172](https://github.com/code-hike/codehike/pull/172) ([@pomber](https://github.com/pomber))
    - Remove target from code links [#169](https://github.com/code-hike/codehike/pull/169) ([@pomber](https://github.com/pomber))
  
  #### 🐛 Bug Fix
  
  - Contentlayer example [#170](https://github.com/code-hike/codehike/pull/170) ([@pomber](https://github.com/pomber))
  - `@code-hike/mdx`
    - Fix react 18 strict mode [#173](https://github.com/code-hike/codehike/pull/173) ([@pomber](https://github.com/pomber))
    - v0.4.0 [#167](https://github.com/code-hike/codehike/pull/167) ([@pomber](https://github.com/pomber))
  
  #### Authors: 1
  
  - Rodrigo Pombo ([@pomber](https://github.com/pomber))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
