### PR TITLE
Add skipLanguages config

### DIFF
--- a/packages/mdx/dev/files.ts
+++ b/packages/mdx/dev/files.ts
@@ -36,6 +36,7 @@ export async function getCode(file: string, config = {}) {
           remarkCodeHike,
           {
             autoImport: false,
+            skipLanguages: ["", "mermaid"],
             showCopyButton: true,
             theme,
             ...config,

--- a/packages/mdx/src/remark/code.ts
+++ b/packages/mdx/src/remark/code.ts
@@ -12,11 +12,18 @@ import { mergeFocus } from "../utils"
 import { CodeNode, SuperNode } from "./nodes"
 import { CodeHikeConfig } from "./config"
 
-export function isEditorNode(node: SuperNode) {
+export function isEditorNode(
+  node: SuperNode,
+  config: CodeHikeConfig
+) {
+  if (node.type === "code") {
+    const lang = (node.lang as string) || ""
+    const shouldSkip = config.skipLanguages.includes(lang)
+    return !shouldSkip
+  }
   return (
-    node.type === "code" ||
-    (node.type === "mdxJsxFlowElement" &&
-      node.name === "CH.Code")
+    node.type === "mdxJsxFlowElement" &&
+    node.name === "CH.Code"
   )
 }
 

--- a/packages/mdx/src/remark/config.ts
+++ b/packages/mdx/src/remark/config.ts
@@ -2,6 +2,7 @@ export type CodeHikeConfig = {
   theme: any
   lineNumbers?: boolean
   autoImport?: boolean
+  skipLanguages: string[]
   showExpandButton?: boolean
   showCopyButton?: boolean
 }
@@ -17,5 +18,6 @@ export function addConfigDefaults(
     ...config,
     theme: config?.theme || {},
     autoImport: config?.autoImport === false ? false : true,
+    skipLanguages: config?.skipLanguages || [],
   }
 }

--- a/packages/mdx/src/remark/steps.tsx
+++ b/packages/mdx/src/remark/steps.tsx
@@ -29,7 +29,7 @@ export async function extractStepsInfo(
 
     steps[stepIndex] = steps[stepIndex] || { children: [] }
     const step = steps[stepIndex]
-    if (!step.editorStep && isEditorNode(child)) {
+    if (!step.editorStep && isEditorNode(child, config)) {
       const editorStep = await mapAnyCodeNode(
         { node: child, parent, index: i },
         config

--- a/packages/mdx/src/remark/transform.code.ts
+++ b/packages/mdx/src/remark/transform.code.ts
@@ -1,5 +1,9 @@
 import { NodeInfo, toJSX, visitAsync } from "./unist-utils"
-import { mapAnyCodeNode, mapEditor } from "./code"
+import {
+  isEditorNode,
+  mapAnyCodeNode,
+  mapEditor,
+} from "./code"
 import { CodeNode, JsxNode, SuperNode } from "./nodes"
 import { CodeHikeConfig } from "./config"
 
@@ -20,7 +24,10 @@ export async function transformCodes(
     tree,
     "code",
     async (node: CodeNode, index, parent) => {
-      await transformCode({ node, index, parent }, config)
+      // here we check if we should skip it because of the language:
+      if (isEditorNode(node, config)) {
+        await transformCode({ node, index, parent }, config)
+      }
     }
   )
 }

--- a/packages/mdx/src/remark/transform.section.ts
+++ b/packages/mdx/src/remark/transform.section.ts
@@ -27,7 +27,7 @@ async function transformSection(
     node,
     ["mdxJsxFlowElement", "code"],
     async (editorNode, index, parent) => {
-      if (isEditorNode(editorNode)) {
+      if (isEditorNode(editorNode, config)) {
         props = await mapAnyCodeNode(
           { node: editorNode, index, parent },
           config


### PR DESCRIPTION
Add `skipLanguages` to Code Hike config. Fix #210 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.6.2--canary.213.47834b0.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @code-hike/mdx@0.6.2--canary.213.47834b0.0
  # or 
  yarn add @code-hike/mdx@0.6.2--canary.213.47834b0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
