### PR TITLE
feat(#246): Add onChange and initialSlideIndex props to CH.Slideshow

### DIFF
--- a/packages/mdx/dev/content/slideshow-onchange.mdx
+++ b/packages/mdx/dev/content/slideshow-onchange.mdx
@@ -2,7 +2,7 @@
 
 Internal CH.Slideshow state object is being logged to console from the onChange event. CH.Slideshow is also being initialized on a different slide number.
 
-<CH.Slideshow preset="https://codesandbox.io/s/rfdho" code={{minZoom: 0.5}} initialSlideIndex={5} onChange={(obj) => console.log(obj)}>
+<CH.Slideshow preset="https://codesandbox.io/s/rfdho" code={{minZoom: 0.5}} start={5} onChange={(obj) => console.table(obj)}>
 
 <CH.Code>
 

--- a/packages/mdx/dev/content/slideshow-onchange.mdx
+++ b/packages/mdx/dev/content/slideshow-onchange.mdx
@@ -1,0 +1,529 @@
+# Slideshow onChange Function
+
+Internal CH.Slideshow state object is being logged to console from the onChange event. CH.Slideshow is also being initialized on a different slide number.
+
+<CH.Slideshow preset="https://codesandbox.io/s/rfdho" code={{minZoom: 0.5}} initialSlideIndex={5} onChange={(obj) => console.log(obj)}>
+
+<CH.Code>
+
+```jsx src/index.js
+import React from "react"
+import ReactDOM from "react-dom"
+
+const app = React.createElement(
+  "h1",
+  { style: { color: "teal" } },
+  "Hello React"
+)
+
+ReactDOM.render(app, document.getElementById("root"))
+```
+
+</CH.Code>
+
+React provides a createElement function to declare what we want to render to the DOM
+
+---
+
+<CH.Code>
+
+```jsx src/index.js focus=4
+import React from "react"
+import ReactDOM from "react-dom"
+
+const app = <h1 style={{ color: "teal" }}>Hello React</h1>
+
+ReactDOM.render(app, document.getElementById("root"))
+```
+
+</CH.Code>
+
+But instead of using createElement directly you can use JSX.
+
+---
+
+<CH.Code>
+
+```jsx src/index.js focus=4:10
+import React from "react"
+import ReactDOM from "react-dom"
+
+function MyComponent() {
+  return (
+    <div>
+      <button>Hello</button>
+    </div>
+  )
+}
+
+const app = <h1 style={{ color: "teal" }}>Hello React</h1>
+
+ReactDOM.render(app, document.getElementById("root"))
+```
+
+</CH.Code>
+
+To create a component you only need to write a function with a name that starts with a capital letter.
+
+---
+
+<CH.Code>
+
+```jsx src/index.js focus=4[10:20],12:17
+import React from "react"
+import ReactDOM from "react-dom"
+
+function MyComponent() {
+  return (
+    <div>
+      <button>Hello</button>
+    </div>
+  )
+}
+
+const app = (
+  <div>
+    <MyComponent />
+    <MyComponent />
+  </div>
+)
+
+ReactDOM.render(app, document.getElementById("root"))
+```
+
+</CH.Code>
+
+Now you can use that function in JSX.
+
+---
+
+<CH.Code>
+
+```jsx src/index.js focus=14[18:29],15[18:31]
+import React from "react"
+import ReactDOM from "react-dom"
+
+function MyComponent() {
+  return (
+    <div>
+      <button>Hello</button>
+    </div>
+  )
+}
+
+const app = (
+  <div>
+    <MyComponent name="Messi" />
+    <MyComponent name="Ronaldo" />
+  </div>
+)
+
+ReactDOM.render(app, document.getElementById("root"))
+```
+
+</CH.Code>
+
+You can assign attributes
+
+---
+
+<CH.Code>
+
+```jsx src/index.js focus=4[22:29],14[18:29],15[18:31]
+import React from "react"
+import ReactDOM from "react-dom"
+
+function MyComponent({ name }) {
+  return (
+    <div>
+      <button>Hello</button>
+    </div>
+  )
+}
+
+const app = (
+  <div>
+    <MyComponent name="Messi" />
+    <MyComponent name="Ronaldo" />
+  </div>
+)
+
+ReactDOM.render(app, document.getElementById("root"))
+```
+
+</CH.Code>
+
+And React will pass them to the component as parameters
+
+---
+
+<CH.Code>
+
+```jsx src/index.js focus=4[22:29],7
+import React from "react"
+import ReactDOM from "react-dom"
+
+function MyComponent({ name }) {
+  return (
+    <div>
+      <button>{name}</button>
+    </div>
+  )
+}
+
+const app = (
+  <div>
+    <MyComponent name="Messi" />
+    <MyComponent name="Ronaldo" />
+  </div>
+)
+
+ReactDOM.render(app, document.getElementById("root"))
+```
+
+</CH.Code>
+
+Inside JSX, you use curly braces to wrap dynamic data
+
+---
+
+<CH.Code>
+
+```jsx src/index.js focus=5,9
+import React from "react"
+import ReactDOM from "react-dom"
+
+function MyComponent({ name }) {
+  const goalCount = 2
+  return (
+    <div>
+      <button>{name}</button>
+      {"⚽".repeat(goalCount)}
+    </div>
+  )
+}
+
+const app = (
+  <div>
+    <MyComponent name="Messi" />
+    <MyComponent name="Ronaldo" />
+  </div>
+)
+
+ReactDOM.render(app, document.getElementById("root"))
+```
+
+</CH.Code>
+
+In fact you can wrap any javascript expression.
+
+---
+
+<CH.Code>
+
+```jsx src/index.js focus=7:9,13[15:35]
+import React from "react"
+import ReactDOM from "react-dom"
+
+function MyComponent({ name }) {
+  const goalCount = 2
+
+  const handleClick = event => {
+    // do something
+  }
+
+  return (
+    <div>
+      <button onClick={handleClick}>{name}</button>
+      {"⚽".repeat(goalCount)}
+    </div>
+  )
+}
+
+const app = (
+  <div>
+    <MyComponent name="Messi" />
+    <MyComponent name="Ronaldo" />
+  </div>
+)
+
+ReactDOM.render(app, document.getElementById("root"))
+```
+
+</CH.Code>
+
+To add event listeners you pass a function to the corresponding attribute
+
+---
+
+<CH.Code>
+
+```jsx src/index.js focus=5
+import React from "react"
+import ReactDOM from "react-dom"
+
+function MyComponent({ name }) {
+  const [goalCount, setCount] = React.useState(2)
+
+  const handleClick = event => {
+    // do something
+  }
+  return (
+    <div>
+      <button onClick={handleClick}>{name}</button>
+      {"⚽".repeat(goalCount)}
+    </div>
+  )
+}
+
+const app = (
+  <div>
+    <MyComponent name="Messi" />
+    <MyComponent name="Ronaldo" />
+  </div>
+)
+
+ReactDOM.render(app, document.getElementById("root"))
+```
+
+</CH.Code>
+
+To add state to a component there's the useState function from React.
+
+---
+
+<CH.Code>
+
+```jsx src/index.js focus=5,7:9
+import React from "react"
+import ReactDOM from "react-dom"
+
+function MyComponent({ name }) {
+  const [goalCount, setCount] = React.useState(2)
+
+  const handleClick = event => {
+    setCount(goalCount + 1)
+  }
+
+  return (
+    <div>
+      <button onClick={handleClick}>{name}</button>
+      {"⚽".repeat(goalCount)}
+    </div>
+  )
+}
+
+const app = (
+  <div>
+    <MyComponent name="Messi" />
+    <MyComponent name="Ronaldo" />
+  </div>
+)
+
+ReactDOM.render(app, document.getElementById("root"))
+```
+
+</CH.Code>
+
+It gives you a function to update the state.
+
+---
+
+<CH.Code>
+
+```jsx src/index.js focus=5,7:9,13,14
+
+```
+
+</CH.Code>
+
+When you call it, React will know it needs to re-render the component.
+
+---
+
+<CH.Code>
+
+```jsx src/index.js focus=19
+import React from "react"
+import ReactDOM from "react-dom"
+
+function MyComponent({ name }) {
+  const [goalCount, setCount] = React.useState(2)
+
+  const handleClick = event => {
+    setCount(goalCount + 1)
+  }
+
+  return (
+    <div>
+      <button onClick={handleClick}>{name}</button>
+      {"⚽".repeat(goalCount)}
+    </div>
+  )
+}
+
+const players = ["Messi", "Ronaldo", "Laspada"]
+
+const app = (
+  <div>
+    <MyComponent name="Messi" />
+    <MyComponent name="Ronaldo" />
+  </div>
+)
+
+ReactDOM.render(app, document.getElementById("root"))
+```
+
+</CH.Code>
+
+To render a list
+
+---
+
+<CH.Code>
+
+```jsx src/index.js focus=19,23[6:34],24,25[1:6]
+import React from "react"
+import ReactDOM from "react-dom"
+
+function MyComponent({ name }) {
+  const [goalCount, setCount] = React.useState(2)
+
+  const handleClick = event => {
+    setCount(goalCount + 1)
+  }
+
+  return (
+    <div>
+      <button onClick={handleClick}>{name}</button>
+      {"⚽".repeat(goalCount)}
+    </div>
+  )
+}
+
+const players = ["Messi", "Ronaldo", "Laspada"]
+
+const app = (
+  <div>
+    {players.map(playerName => (
+      <MyComponent name={playerName} key={playerName} />
+    ))}
+  </div>
+)
+
+ReactDOM.render(app, document.getElementById("root"))
+```
+
+</CH.Code>
+
+you can map each list item to an element using javascript.
+
+---
+
+<CH.Code>
+
+```jsx src/index.js focus=24[38:54]
+
+```
+
+</CH.Code>
+
+React only needs a unique key for each element, to find out when something changes.
+
+---
+
+<CH.Code>
+
+```jsx src/index.js focus=21:27,30,34
+import React from "react"
+import ReactDOM from "react-dom"
+
+function MyComponent({ name }) {
+  const [goalCount, setCount] = React.useState(2)
+
+  const handleClick = event => {
+    setCount(goalCount + 1)
+  }
+
+  return (
+    <div>
+      <button onClick={handleClick}>{name}</button>
+      {"⚽".repeat(goalCount)}
+    </div>
+  )
+}
+
+const players = ["Messi", "Ronaldo", "Laspada"]
+
+function MyBox() {
+  return (
+    <div style={{ border: "8px solid deeppink" }}>
+      // TODO something
+    </div>
+  )
+}
+
+const app = (
+  <MyBox>
+    {players.map(playerName => (
+      <MyComponent name={playerName} key={playerName} />
+    ))}
+  </MyBox>
+)
+
+ReactDOM.render(app, document.getElementById("root"))
+```
+
+</CH.Code>
+
+If you want to compose components together
+
+---
+
+<CH.Code>
+
+```jsx src/index.js focus=21[16:27],24,30:34
+import React from "react"
+import ReactDOM from "react-dom"
+
+function MyComponent({ name }) {
+  const [goalCount, setCount] = React.useState(2)
+
+  const handleClick = event => {
+    setCount(goalCount + 1)
+  }
+
+  return (
+    <div>
+      <button onClick={handleClick}>{name}</button>
+      {"⚽".repeat(goalCount)}
+    </div>
+  )
+}
+
+const players = ["Messi", "Ronaldo", "Laspada"]
+
+function MyBox({ children }) {
+  return (
+    <div style={{ border: "8px solid deeppink" }}>
+      {children}
+    </div>
+  )
+}
+
+const app = (
+  <MyBox>
+    {players.map(playerName => (
+      <MyComponent name={playerName} key={playerName} />
+    ))}
+  </MyBox>
+)
+
+ReactDOM.render(app, document.getElementById("root"))
+```
+
+</CH.Code>
+
+React passes the nested elements inside a special property called children.
+
+</CH.Slideshow>

--- a/packages/mdx/src/mdx-client/slideshow.tsx
+++ b/packages/mdx/src/mdx-client/slideshow.tsx
@@ -51,13 +51,21 @@ export function Slideshow({
     stepIndex: initialSlide,
     step: editorSteps[initialSlide],
   })
-  const tab = state.step
+
+  // Destructure these values and give them more semantic names for use below
+  const {
+    stepIndex: currentSlideIndex,
+    step: tab,
+  } = state;
 
   // Run any time our Slideshow state changes
   React.useEffect(() => {
     // Return our state object to the Slideshow onChange function
-    onSlideshowChange(state);
-  }, [state]);
+    onSlideshowChange({
+      index: currentSlideIndex
+    });
+    // We are only calling this effect if the current slide changes.
+  }, [currentSlideIndex]);
 
   function onTabClick(filename: string) {
     const newStep = updateEditorStep(
@@ -95,7 +103,7 @@ export function Slideshow({
         ) : hasPreviewSteps ? (
           <Preview
             className="ch-slideshow-preview"
-            {...previewChildren[state.stepIndex]["props"]}
+            {...previewChildren[currentSlideIndex]["props"]}
           />
         ) : null}
       </div>
@@ -151,7 +159,7 @@ export function Slideshow({
 
         {hasNotes && (
           <div className="ch-slideshow-note">
-            {stepsChildren[state.stepIndex]}
+            {stepsChildren[currentSlideIndex]}
           </div>
         )}
       </div>

--- a/packages/mdx/src/mdx-client/slideshow.tsx
+++ b/packages/mdx/src/mdx-client/slideshow.tsx
@@ -13,7 +13,7 @@ export function Slideshow({
   editorSteps,
   hasPreviewSteps,
   // Set the initial slide index
-  initialSlideIndex = 0,
+  start = 0,
   // Called when the slideshow state changes and returns the current state object
   onChange: onSlideshowChange = () => {},
   presetConfig,
@@ -26,7 +26,7 @@ export function Slideshow({
   codeConfig: EditorProps["codeConfig"]
   editorSteps: EditorStep[]
   hasPreviewSteps?: boolean
-  initialSlideIndex?: number
+  start?: number
   onChange?: Function
   presetConfig?: PresetConfig
   style?: React.CSSProperties
@@ -41,8 +41,8 @@ export function Slideshow({
 
   const maxSteps = editorSteps.length - 1;
 
-  // This hook will prevent the slide from being changed via the initialSlideIndex prop after render
-  const initialSlideValue = useInitialState(initialSlideIndex);
+  // This hook will prevent the slide from being changed via the start prop after render
+  const initialSlideValue = useInitialState(start);
 
   // Make sure the initial slide is not configured out of bounds
   const initialSlide = initialSlideValue > maxSteps ? maxSteps : initialSlideValue

--- a/packages/mdx/src/mdx-client/slideshow.tsx
+++ b/packages/mdx/src/mdx-client/slideshow.tsx
@@ -3,7 +3,6 @@ import { EditorProps, EditorStep } from "../mini-editor"
 import { InnerCode, updateEditorStep } from "./code"
 import { Preview, PresetConfig } from "./preview"
 import { extractPreviewSteps } from "./steps"
-import { useInitialState } from "utils"
 
 export function Slideshow({
   children,
@@ -50,11 +49,8 @@ export function Slideshow({
 
   const maxSteps = editorSteps.length - 1;
 
-  // This hook will prevent the slide from being changed via the start prop after render
-  const initialSlideValue = useInitialState(start);
-
   // Make sure the initial slide is not configured out of bounds
-  const initialSlide = initialSlideValue > maxSteps ? maxSteps : initialSlideValue
+  const initialSlide = start > maxSteps ? maxSteps : start
 
   const [state, setState] = React.useState({
     stepIndex: initialSlide,

--- a/packages/mdx/src/utils/hooks.ts
+++ b/packages/mdx/src/utils/hooks.ts
@@ -5,6 +5,12 @@ export const useLayoutEffect =
     ? React.useLayoutEffect
     : React.useEffect
 
+// Returns the same state, even if the state argument changes.
+export function useInitialState<T> (value: T | (() => T)) {
+  const [initialState] = React.useState(value);
+  return initialState;
+}
+
 // for debugging:
 // export const useLayoutEffect = (
 //   effect: any,

--- a/packages/mdx/src/utils/hooks.ts
+++ b/packages/mdx/src/utils/hooks.ts
@@ -5,12 +5,6 @@ export const useLayoutEffect =
     ? React.useLayoutEffect
     : React.useEffect
 
-// Returns the same state, even if the state argument changes.
-export function useInitialState<T> (value: T | (() => T)) {
-  const [initialState] = React.useState(value);
-  return initialState;
-}
-
 // for debugging:
 // export const useLayoutEffect = (
 //   effect: any,


### PR DESCRIPTION
Resolves #246 

For the proposed use case, it is not enough to only initialize the Slideshow component with a starting slide. There also needed to be a way to expose the current slide so that someone could use that value to set in the current URL.

- Adds an `initialSlideIndex` prop which allows initializing CH.Slideshow on a specific slide
  - Includes a new `useInitialState` hook which is used to make sure changing the initialSlideIndex after mount would not control the component
  - Includes a check to make sure the initial slide does not get set greater than the max slides in the MDX file
  - Includes MDX example of this prop in use

- Adds an `onChange` function to the CH.Slideshow component which will get called every time the internal Slideshow state changes, and will return the internal state object
  - NOTE: If we wanted to only return the current slide and not the whole state object, I could make those changes to limit what we are exposing
  - NOTE: Since state changes do not happen from only one event, I did not think it made sense to also try to return different React synthetic events from the onChange in addition to the state data