### PR TITLE
fix: overscroll behaviour for code blocks

### DIFF
--- a/packages/mdx/src/smooth-code/smooth-container.tsx
+++ b/packages/mdx/src/smooth-code/smooth-container.tsx
@@ -101,6 +101,7 @@ function Container({
         height,
         position: "relative",
         overflow: "auto",
+        overscrollBehavior: "auto",
       }}
       className="ch-code-scroll-parent"
       children={children}


### PR DESCRIPTION
I found an issue with code blocks that block the user from scrolling the whole page, because `overflow: auto` catches the scroll and does not propagate it to the document. 

Repro for the issue: https://github.com/MarkusWendorf/codehike-overscroll
* npm i
* npm run dev
* goto http://localhost:3000/posts/react/components
* place cursor inside the **second** code block and try to scroll the document
* it does not scroll unless adding `overscroll-behaviour: "auto"` to `ch-code-scroll-parent`

This PR fixes that behaviour by adding `overscroll-behaviour: "auto"` to `ch-code-scroll-parent`.
