### PR TITLE
Change code height with `rows`

### DIFF
--- a/packages/mdx/dev/content/rows.mdx
+++ b/packages/mdx/dev/content/rows.mdx
@@ -20,6 +20,20 @@ console.log(7)
 
 </CH.Code>
 
+<CH.Code rows="focus" showCopyButton={false} lineNumbers >
+
+```js focus=3:4,6[1:11]
+console.log(1)
+console.log(2)
+console.log(3)
+console.log(4)
+console.log(5)
+console.log(6)
+console.log(7)
+```
+
+</CH.Code>
+
 <CH.Code rows={4} style={{width: 200 }} lineNumbers >
 
 ```js

--- a/packages/mdx/dev/content/rows.mdx
+++ b/packages/mdx/dev/content/rows.mdx
@@ -1,0 +1,53 @@
+<CH.Code rows={4} showCopyButton={false}>
+
+```js
+console.log(2)
+```
+
+</CH.Code>
+
+<CH.Code rows={4} showCopyButton={false} lineNumbers >
+
+```js
+console.log(1)
+console.log(2)
+console.log(3)
+console.log(4)
+console.log(5)
+console.log(6)
+console.log(7)
+```
+
+</CH.Code>
+
+<CH.Code rows={4} style={{width: 200 }} lineNumbers >
+
+```js
+console.log(1)
+console.log(2)
+console.log(3)
+console.log(4)
+console.log(5)
+// focus
+console.log(600000)
+console.log(7)
+```
+
+</CH.Code>
+
+<CH.Code rows={6}  lineNumbers >
+
+```js foo.js
+console.log(1)
+```
+
+```js bar.js
+console.log(1)
+console.log(2)
+console.log(3)
+console.log(4)
+console.log(5)
+console.log(7)
+```
+
+</CH.Code>

--- a/packages/mdx/src/mdx-client/code.tsx
+++ b/packages/mdx/src/mdx-client/code.tsx
@@ -55,6 +55,7 @@ export function mergeCodeConfig<T>(
       showExpandButton == null
         ? props.codeConfig?.showExpandButton
         : showExpandButton,
+    rows: props.rows,
     debug: props.debug ?? props.codeConfig?.debug,
   }
   return { ...rest, codeConfig }

--- a/packages/mdx/src/smooth-code/code-tween.tsx
+++ b/packages/mdx/src/smooth-code/code-tween.tsx
@@ -48,6 +48,7 @@ export type CodeConfig = {
   showCopyButton?: boolean
   showExpandButton?: boolean
   staticMediaQuery?: string
+  rows?: number | "focus"
   debug?: boolean
 }
 
@@ -85,6 +86,7 @@ export function CodeTween({
     map(tween, tween => tween.focus),
     config.minColumns || DEFAULT_MIN_COLUMNS,
     config.lineNumbers || false,
+    config.rows,
     [config.parentHeight]
   )
 

--- a/packages/mdx/src/utils/focus.ts
+++ b/packages/mdx/src/utils/focus.ts
@@ -102,7 +102,7 @@ export function parseExtremes(part: string) {
 /**
  * Return the first and last indexes to focus, both included
  */
-function getFocusExtremes(
+export function getFocusExtremes(
   focus: FocusString,
   lines: any[]
 ): [number, number] {


### PR DESCRIPTION
Fix #258

Forcing 4 lines of height:

````md
<CH.Code rows={4}>

```js
console.log(1)
console.log(2)
console.log(3)
console.log(4)
console.log(5)
console.log(6)
console.log(7)
```

</CH.Code>
````

Forcing the height to match the focused code:


````md
<CH.Code rows="focus">

```js focus=3:4,6
console.log(1)
console.log(2)
console.log(3)
console.log(4)
console.log(5)
console.log(6)
console.log(7)
```

</CH.Code>
````

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.3--canary.262.fb2e24d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @code-hike/mdx@0.7.3--canary.262.fb2e24d.0
  # or 
  yarn add @code-hike/mdx@0.7.3--canary.262.fb2e24d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
