### PR TITLE
Force content box in code-wrapper

### DIFF
--- a/packages/mdx/src/smooth-code/code-tween.tsx
+++ b/packages/mdx/src/smooth-code/code-tween.tsx
@@ -192,6 +192,7 @@ function Wrapper({
 }) {
   return (
     <div
+      className="ch-code-wrapper"
       {...htmlProps}
       style={{
         margin: 0,
@@ -199,6 +200,8 @@ function Wrapper({
         position: "relative",
         // using this instead of <pre> because https://github.com/code-hike/codehike/issues/120
         whiteSpace: "pre",
+        // to avoid resets using "border-box" that break the scrollbar https://github.com/code-hike/codehike/issues/240
+        boxSizing: "content-box",
         ...style,
         ...htmlProps?.style,
       }}


### PR DESCRIPTION
Fix #240 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.7.4--canary.267.6ac2b96.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @code-hike/mdx@0.7.4--canary.267.6ac2b96.0
  # or 
  yarn add @code-hike/mdx@0.7.4--canary.267.6ac2b96.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
