### PR TITLE
add outline-color to button-reset mixin 

### DIFF
--- a/packages/mdx/src/utils/mixins.scss
+++ b/packages/mdx/src/utils/mixins.scss
@@ -8,4 +8,5 @@
   padding: 0;
   border: none;
   font-size: inherit;
+  outline-color: currentColor;
 }


### PR DESCRIPTION
A small change to improve the accessibility of the copy buttons,  followin up #341

Here I'm making sure the buttons show a visible outline when focused on using the keyboard
