### PR TITLE
Fix dimensions when code starts hidden

### DIFF
--- a/packages/mdx/src/highlighter/index.tsx
+++ b/packages/mdx/src/highlighter/index.tsx
@@ -3,6 +3,8 @@ import { highlight as light } from "@code-hike/lighter"
 
 const newlineRe = /\r\n|\r|\n/
 
+const warnings = new Set()
+
 export async function highlight({
   code,
   lang,
@@ -35,10 +37,13 @@ export async function highlight({
     return { lines, lang }
   } catch (e) {
     // TODO check error is "missing grammar"
-    console.warn(
-      "[Code Hike warning]",
-      `${lang} is not a valid language, no syntax highlighting will be applied.`
-    )
+    if (!warnings.has(lang)) {
+      console.warn(
+        "[Code Hike warning]",
+        `${lang} is not a valid language, no syntax highlighting will be applied.`
+      )
+      warnings.add(lang)
+    }
     return highlight({ code, lang: "text", theme })
   }
 }

--- a/packages/mdx/src/smooth-code/code-tween.tsx
+++ b/packages/mdx/src/smooth-code/code-tween.tsx
@@ -109,10 +109,7 @@ function BeforeDimensions({
   debug?: boolean
 }) {
   return (
-    <Wrapper
-      htmlProps={htmlProps}
-      style={{ opacity: debug ? 0.9 : 0, overflow: "auto" }}
-    >
+    <Wrapper htmlProps={htmlProps} measured={false}>
       {element}
     </Wrapper>
   )
@@ -137,7 +134,7 @@ function AfterDimensions({
   htmlProps: HTMLProps
 }) {
   return (
-    <Wrapper htmlProps={htmlProps} style={{ opacity: 1 }}>
+    <Wrapper htmlProps={htmlProps} measured={true}>
       <SmoothLines
         codeStep={stepInfo}
         progress={progress}
@@ -159,12 +156,12 @@ function AfterDimensions({
 
 function Wrapper({
   htmlProps,
-  style,
   children,
+  measured,
 }: {
   htmlProps?: HTMLProps
-  style: React.CSSProperties
   children: React.ReactNode
+  measured: boolean
 }) {
   return (
     // not using <pre> because https://github.com/code-hike/codehike/issues/120
@@ -173,10 +170,7 @@ function Wrapper({
       className={`ch-code-wrapper ${
         htmlProps?.className || ""
       }`}
-      style={{
-        ...style,
-        ...htmlProps?.style,
-      }}
+      data-ch-measured={measured}
       children={children}
     />
   )

--- a/packages/mdx/src/smooth-code/index.scss
+++ b/packages/mdx/src/smooth-code/index.scss
@@ -51,3 +51,9 @@
   // to avoid resets using "border-box" that break the scrollbar https://github.com/code-hike/codehike/issues/240
   box-sizing: content-box;
 }
+.ch-code-wrapper[data-ch-measured="false"] {
+  overflow: auto;
+}
+.ch-code-wrapper[data-ch-measured="false"] > * {
+  opacity: 0;
+}


### PR DESCRIPTION
Fix #372, fix #371, fix #340, fix #319, fix #279.

If the code starts hidden (for example, inside an inactive tab) use a ResizeObserver to recalculate dimensions when it's displayed later.


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.9.0--canary.373.22ed7cb.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @code-hike/mdx@0.9.0--canary.373.22ed7cb.0
  # or 
  yarn add @code-hike/mdx@0.9.0--canary.373.22ed7cb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
