### PR TITLE
`from` annotation with line range

### DIFF
--- a/packages/mdx/dev/content/assets/bar.js
+++ b/packages/mdx/dev/content/assets/bar.js
@@ -1,0 +1,7 @@
+console.log("one")
+console.log("two")
+console.log("three")
+console.log("four")
+console.log("five")
+console.log("six")
+console.log("seven")

--- a/packages/mdx/dev/content/external.mdx
+++ b/packages/mdx/dev/content/external.mdx
@@ -2,6 +2,10 @@
 // from ./assets/foo.js
 ```
 
+```js bar.js
+// from ./assets/bar.js     3:5
+```
+
 ```py foo.py
 # from ./assets/foo.py
 ```


### PR DESCRIPTION
Fix #375 

Now it's possible to include a range of lines using the `from` annotation (range starts at 1, not 0).

````md
```py
# from ./some/file.py 4:7
```
````