### PR TITLE
Stable dimensions

### DIFF
--- a/packages/mdx/dev/content/scrollycoding-demo.mdx
+++ b/packages/mdx/dev/content/scrollycoding-demo.mdx
@@ -73,6 +73,8 @@ Morbi quis commodo.
 
 ```
 
+Lorem [ipsum](focus://3)
+
 ---
 
 ## Step 3

--- a/packages/mdx/src/smooth-code/use-dimensions.tsx
+++ b/packages/mdx/src/smooth-code/use-dimensions.tsx
@@ -136,8 +136,8 @@ function useDimensions(
   const allDeps = [
     ...deps,
     windowWidth,
-    prevLongestLine,
-    nextLongestLine,
+    // prevLongestLine,
+    // nextLongestLine,
     minColumns,
     visibility,
   ]


### PR DESCRIPTION
Don't chante dimensions when the focus changes.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.9.1--canary.397.c7a9d9d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @code-hike/mdx@0.9.1--canary.397.c7a9d9d.0
  # or 
  yarn add @code-hike/mdx@0.9.1--canary.397.c7a9d9d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
