### PR TITLE
377 focus out of bound

### DIFF
--- a/packages/mdx/src/utils/focus.test.ts
+++ b/packages/mdx/src/utils/focus.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, test } from "vitest"
 
 import {
+  getFocusIndexes,
   mapFocusToLineNumbers,
   relativeToAbsolute,
 } from "./focus"
@@ -33,3 +34,31 @@ describe("relative to absolute", () => {
     )
   })
 })
+
+describe("get focus indexes", () => {
+  it("return correct focus indexes", () => {
+    expect(getFocusIndexes("3:4", fixtureCode)).toEqual([2, 3])
+    expect(getFocusIndexes("1:8", fixtureCode)).toEqual([0, 1, 2, 3, 4, 5, 6, 7])
+  })
+  it("return all lines when focus string is empty", () => {
+    expect(getFocusIndexes(null, fixtureCode)).toEqual([0, 1, 2, 3, 4, 5, 6, 7])
+    expect(getFocusIndexes("", fixtureCode)).toEqual([0, 1, 2, 3, 4, 5, 6, 7])
+  })
+  it("throws error if one or many indexes are larger than lines count", () => {
+    expect(() => getFocusIndexes("13:14", fixtureCode)).toThrowError("Out of bound focus line number(s)")
+    expect(() => getFocusIndexes("7:9", fixtureCode)).toThrowError("Out of bound focus line number(s)")
+    expect(() => getFocusIndexes("1:3,7:9", fixtureCode)).toThrowError("Out of bound focus line number(s)")
+  })
+})
+
+const fixtureCode = [
+  "function doStuffToFoo(foo: any) {",
+  "",
+  " const bar = doStuff(foo)",
+  " if(!bar)",
+  "   return null",
+  "",
+  " return bar",
+  "}",
+]
+

--- a/packages/mdx/src/utils/focus.ts
+++ b/packages/mdx/src/utils/focus.ts
@@ -132,8 +132,8 @@ export function getFocusIndexes(
     parseInt(i, 10)
   )
 
-  const isIndexOutOfRange = focusedIndexes.some(i => i > lines.length)
-  if(isIndexOutOfRange)
+  const hasOutOfRangeIndex = focusedIndexes.some(i => i + 1 > lines.length)
+  if(hasOutOfRangeIndex)
     throw new Error("Out of bound focus line number(s)")
 
   return focusedIndexes

--- a/packages/mdx/src/utils/focus.ts
+++ b/packages/mdx/src/utils/focus.ts
@@ -124,15 +124,19 @@ export function getFocusIndexes(
   focus: FocusString,
   lines: any[]
 ): number[] {
-  if (!focus) {
-    return [...lines.keys()]
-  } else {
-    const parsed = parseFocus(focus)
-    const focusedIndexes = Object.keys(parsed).map(i =>
-      parseInt(i, 10)
-    )
-    return focusedIndexes
-  }
+  if (!focus)
+    return [...lines.keys()]  
+
+  const parsed = parseFocus(focus)
+  const focusedIndexes = Object.keys(parsed).map(i =>
+    parseInt(i, 10)
+  )
+
+  const isIndexOutOfRange = focusedIndexes.some(i => i > lines.length)
+  if(isIndexOutOfRange)
+    throw new Error("Out of bound focus line number(s)")
+
+  return focusedIndexes
 }
 
 function getFocusByKey(focus: FocusString, keys: number[]) {


### PR DESCRIPTION
Handles a case where the focus string contains line index(es) that are larger than the last line's index. Throws an error.

Added tests to cover that function.