### PR TITLE
Remove type annotation on CH export

### DIFF
--- a/examples/contentlayer/tsconfig.json
+++ b/examples/contentlayer/tsconfig.json
@@ -19,8 +19,12 @@
       "contentlayer/generated": ["./.contentlayer/generated"]
     }
   },
+  "mdx": {
+    "checkMdx": true
+  },
   "include": [
     "next-env.d.ts",
+    "**/*.mdx",
     "**/*.ts",
     "**/*.tsx",
     ".contentlayer/generated"

--- a/examples/contentlayer/types.ts
+++ b/examples/contentlayer/types.ts
@@ -1,0 +1,9 @@
+import { CH } from "@code-hike/mdx/components"
+
+declare global {
+  interface MDXProvidedComponents {
+    CH: typeof CH
+  }
+}
+
+export {}

--- a/packages/mdx/src/components.tsx
+++ b/packages/mdx/src/components.tsx
@@ -14,7 +14,6 @@ import {
 } from "./mdx-client/annotations"
 import { Preview } from "./mdx-client/preview"
 import { InlineCode } from "./mdx-client/inline-code"
-import type { MDXComponents } from "mdx/types"
 import {
   useStaticToggle,
   StaticToggle,
@@ -38,7 +37,7 @@ export {
   StaticToggle,
 }
 
-export const CH: MDXComponents = {
+export const CH = {
   Code,
   Section,
   SectionLink,


### PR DESCRIPTION
Removing the type annotation on `CH`, means TypeScript infers its type. This type can then be used by the MDX language server to provide type safe JSX inside MDX files.

The `contentlayer` example was updated to leverage MDX language server for type safety. For now type safety only happens in the editor, there is no CLI support yet.

There is a type error in `examples/contentlayer/posts/two.mdx`.