### PR TITLE
Make remarkCodeHike work at Next.js edge runtime

### DIFF
--- a/.changeset/warm-bottles-fly.md
+++ b/.changeset/warm-bottles-fly.md
@@ -1,0 +1,5 @@
+---
+"codehike": patch
+---
+
+Make remarkCodeHike work at Next.js edge runtime

--- a/.changeset/warm-bottles-fly.md
+++ b/.changeset/warm-bottles-fly.md
@@ -2,4 +2,4 @@
 "codehike": patch
 ---
 
-Make remarkCodeHike work at Next.js edge runtime
+Make `remarkCodeHike` work at Next.js edge runtime

--- a/packages/codehike/src/mdx/0.import-code-from-path.ts
+++ b/packages/codehike/src/mdx/0.import-code-from-path.ts
@@ -56,8 +56,8 @@ async function readFile(
   let fs, path
 
   try {
-    fs = (await import("fs")).default
-    path = (await import("path")).default
+    fs = require("fs")
+    path = require("path")
     if (!fs || !fs.readFileSync || !path || !path.resolve) {
       throw new Error("fs or path not found")
     }


### PR DESCRIPTION
### The issue

I am trying to integrate Code Hike into a Next.js project using the Edge Runtime. I referred to this project： 

https://github.com/code-hike/examples/tree/next-mdx-remote/with-next-mdx-remote-rsc

and added this line of code to `page.tsx`:

```tsx
export const runtime = "edge"
```

I noticed that `page.tsx` import fs from "fs", which is not available in edge. So I just hard code `source` to test if Code Hike works.

```diff
- import { promises as fs } from "fs"

+ export const runtime = "edge"

export default async function Home() {
-  const source = await fs.readFile("./content/index.md", "utf-8")
+  const source = "# title";

  const { content } = await compileMDX({
    source,
    components,
    options: {
```

Unfortunately, it threw an `compile error` caused by import "fs" module inside of `codehike/dist/mdx.js`.

<img width="989" alt="image" src="https://github.com/user-attachments/assets/be7a0f55-a6df-46a6-a453-8bbdd40f2b32">

Then I found the problematic code:

https://github.com/code-hike/codehike/blob/7e7b78d75ec24db7293b5d01475f3cf67c20bcea/packages/codehike/src/mdx/0.import-code-from-path.ts#L56-L64

When using Webpack, dynamic imports with import() can prevent exceptions from being caught by try-catch.

**Even if I didn’t use Code Hike’s `!from` feature to import external code.** 

### The solution

Changing `import` to `require` resolves this issue. Because `require` imports modules at runtime, while `import` does so at compile time.
