### PR TITLE
Improve text contrast for hover and focus examples in light mode

### DIFF
--- a/apps/web/demos/focus/code.tsx
+++ b/apps/web/demos/focus/code.tsx
@@ -35,10 +35,10 @@ export function CodeContainer({ code }: { code: HighlightedCode }) {
         }}
         handlers={[focus]}
       />
-      <div className="p-2 mt-auto font-light text-center">
+      <div className="p-2 mt-auto font-light text-center text-white">
         You can also change the focus annotations on a rendered codeblock:
       </div>
-      <div className="flex justify-center gap-2 pb-4">
+      <div className="flex justify-center gap-2 pb-4 text-white">
         <button
           onClick={() => setFocused("lorem")}
           disabled={focused === "lorem"}

--- a/apps/web/demos/hover/page.tsx
+++ b/apps/web/demos/hover/page.tsx
@@ -16,7 +16,7 @@ export default function Page() {
 
 function HoverContainer(props: { children: React.ReactNode }) {
   return (
-    <div className="bg-zinc-900/80 px-2 rounded hover-container">
+    <div className="bg-zinc-900/80 px-2 rounded hover-container text-white">
       {props.children}
     </div>
   )


### PR DESCRIPTION
Hi there, thanks for the great work! I noticed that the [code mention](https://codehike.org/docs/code/code-mentions) and [focus](https://codehike.org/docs/code/focus) examples have low text contrast in light mode, so I created a fix for it. Feel free to close this if I missed something obvious.

## Before

![image](https://github.com/user-attachments/assets/3de7c8b3-e5cb-442c-953c-5d1e2a61949b)

![image](https://github.com/user-attachments/assets/db2153b3-3224-4392-8053-9f9557471568)

## After

![image](https://github.com/user-attachments/assets/67442e26-63ed-480a-9fd8-e6b776218fc5)

![image](https://github.com/user-attachments/assets/7fec20fb-1b8e-445f-bbba-8daa4679e710)
