### PR TITLE
More flexible !from directive

### DIFF
--- a/.changeset/silent-shoes-add.md
+++ b/.changeset/silent-shoes-add.md
@@ -1,0 +1,5 @@
+---
+"codehike": patch
+---
+
+More flexible `!from` directive

--- a/apps/web/content/docs/concepts/assets/index.js
+++ b/apps/web/content/docs/concepts/assets/index.js
@@ -1,0 +1,1 @@
+!from ./assets/index.js

--- a/apps/web/content/docs/concepts/code.mdx
+++ b/apps/web/content/docs/concepts/code.mdx
@@ -129,7 +129,7 @@ You can use the [Theme Editor](https://themes.codehike.org/editor) to customize 
 To include code from a file in your markdown codeblocks, you can use the `!from` directive followed by the path to the file (relative to the markdown file).
 
 ````txt
-```js index.js
+```js
 !from ./assets/index.js
 ```
 ````

--- a/packages/codehike/tests/md-suite/_readme.md
+++ b/packages/codehike/tests/md-suite/_readme.md
@@ -13,13 +13,20 @@ snapshots:
   - after-rehype
   - before-recma-compiled-js
   - before-recma-compiled-jsx
+  - before-recma-compiled-function
   - before-recma-js
+  - before-recma-js-dev
   - before-recma-jsx
   - after-recma-js
+  - after-recma-js-dev
   - after-recma-jsx
   - compiled-js
+  - compiled-js-dev
   - compiled-jsx
+  - compiled-function
   - parsed-jsx
+  - rendered
+  - rendered-dev
 ---
 ```
 

--- a/packages/codehike/tests/md-suite/assets/test.py
+++ b/packages/codehike/tests/md-suite/assets/test.py
@@ -1,4 +1,3 @@
+# !mark inside
 import random
-
-my_list = [1, 'a', 32, 'c', 'd', 31]
-print(random.choice(my_list))
+my_list = []

--- a/packages/codehike/tests/md-suite/import-code.0.mdx
+++ b/packages/codehike/tests/md-suite/import-code.0.mdx
@@ -1,6 +1,7 @@
 ---
 snapshots:
   - compiled-jsx
+  - rendered
 ---
 
 hello
@@ -10,5 +11,15 @@ hello
 ```
 
 ```py !
+!from ./assets/test.py
+```
+
+```py
+# !mark(2) bar
+!from ./assets/test.py
+
+def hello():
+    print("hello")
+
 !from ./assets/test.py
 ```

--- a/packages/codehike/tests/md-suite/import-code.0.render.tsx
+++ b/packages/codehike/tests/md-suite/import-code.0.render.tsx
@@ -1,0 +1,21 @@
+import { MDXContent } from "mdx/types"
+import { AnnotationHandler, highlight, Pre, RawCode } from "../../src/code"
+import React from "react"
+
+export function render(Content: MDXContent) {
+  // @ts-ignore
+  return <Content components={{ MyCode }} />
+}
+
+async function MyCode({ codeblock }: { codeblock: RawCode }) {
+  const highlighted = await highlight(codeblock, "github-dark")
+  return <Pre code={highlighted} handlers={[mark]} />
+}
+
+const mark: AnnotationHandler = {
+  name: "mark",
+  Pre: ({ _stack, ...props }) => <section {...props} />,
+  Block: ({ children, annotation }) => (
+    <mark className={annotation.query}>{children}</mark>
+  ),
+}

--- a/packages/codehike/tests/md-suite/import-code.7.compiled-jsx.jsx
+++ b/packages/codehike/tests/md-suite/import-code.7.compiled-jsx.jsx
@@ -13,8 +13,15 @@ function _createMdxContent(props) {
         <_components.p>{"hello"}</_components.p>
         <MyCode
           codeblock={{
+            value: "# !mark inside\r\nimport random\r\nmy_list = []",
+            lang: "py",
+            meta: "",
+          }}
+        />
+        <MyCode
+          codeblock={{
             value:
-              "import random\r\n\r\nmy_list = [1, 'a', 32, 'c', 'd', 31]\r\nprint(random.choice(my_list))",
+              '# !mark(2) bar\r\n# !mark inside\r\nimport random\r\nmy_list = []\n\r\ndef hello():\r\n    print("hello")\r\n\r\n# !mark inside\r\nimport random\r\nmy_list = []',
             lang: "py",
             meta: "",
           }}
@@ -26,8 +33,7 @@ function _createMdxContent(props) {
       header: "",
     },
     code: {
-      value:
-        "import random\r\n\r\nmy_list = [1, 'a', 32, 'c', 'd', 31]\r\nprint(random.choice(my_list))",
+      value: "# !mark inside\r\nimport random\r\nmy_list = []",
       lang: "py",
       meta: "",
     },

--- a/packages/codehike/tests/md-suite/import-code.9.rendered.html
+++ b/packages/codehike/tests/md-suite/import-code.9.rendered.html
@@ -1,0 +1,53 @@
+<p>hello</p>
+<section data-theme="github-dark" data-lang="python">
+  <mark class="inside">
+    <div>
+      <span style="color: #ff7b72">import</span>
+      <span style="color: #c9d1d9">random</span>
+    </div>
+  </mark>
+  <div>
+    <span style="color: #c9d1d9">my_list</span>
+    <span style="color: #ff7b72">=</span>
+    <span style="color: #c9d1d9">[]</span>
+  </div>
+</section>
+<section data-theme="github-dark" data-lang="python">
+  <mark class="inside">
+    <div>
+      <span style="color: #ff7b72">import</span>
+      <span style="color: #c9d1d9">random</span>
+    </div>
+  </mark>
+  <mark class="bar">
+    <div>
+      <span style="color: #c9d1d9">my_list</span>
+      <span style="color: #ff7b72">=</span>
+      <span style="color: #c9d1d9">[]</span>
+    </div>
+  </mark>
+  <div></div>
+  <div>
+    <span style="color: #ff7b72">def</span>
+    <span style="color: #d2a8ff">hello</span>
+    <span style="color: #c9d1d9">():</span>
+  </div>
+  <div>
+    <span style="color: #79c0ff">print</span>
+    <span style="color: #c9d1d9">(</span>
+    <span style="color: #a5d6ff">&quot;hello&quot;</span>
+    <span style="color: #c9d1d9">)</span>
+  </div>
+  <div></div>
+  <mark class="inside">
+    <div>
+      <span style="color: #ff7b72">import</span>
+      <span style="color: #c9d1d9">random</span>
+    </div>
+  </mark>
+  <div>
+    <span style="color: #c9d1d9">my_list</span>
+    <span style="color: #ff7b72">=</span>
+    <span style="color: #c9d1d9">[]</span>
+  </div>
+</section>


### PR DESCRIPTION
Fix #439

Now we can mix `!from` with more code, annotations, or even more `!from` directives

````md
```py
# !mark(2) bar
!from ./assets/test.py

def hello():
    print("hello")

!from ./assets/test.py
```
````