### PR TITLE
fix: declare zod peer dependency

### DIFF
--- a/.changeset/tidy-pears-yawn.md
+++ b/.changeset/tidy-pears-yawn.md
@@ -1,0 +1,5 @@
+---
+"codehike": patch
+---
+
+Declare zod as a peer dependency because `codehike/blocks` imports it at runtime and exposes zod v3 schema types.

--- a/packages/codehike/package.json
+++ b/packages/codehike/package.json
@@ -59,6 +59,9 @@
     "mdast-util-mdx-jsx": "^3.0.0",
     "unist-util-visit": "^5.0.0"
   },
+  "peerDependencies": {
+    "zod": "^3.22.4"
+  },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.4",
     "@mdx-js/mdx": "^3.0.0",


### PR DESCRIPTION
## Summary

`codehike/blocks` imports `zod` at runtime and exposes zod v3 schema types in its declarations, but the package currently only lists `zod` in `devDependencies`. Package managers therefore may not install a compatible zod copy for consumers, and projects that already resolve `zod@4` can end up type-checking `codehike/blocks` against the wrong major version.

This adds `zod` as a peer dependency with the existing v3-compatible range and includes a patch changeset. The dev dependency remains so this package can still build and test itself.

